### PR TITLE
Examples upgrade due to problems Console

### DIFF
--- a/arduino/SpacebrewYun/examples/inputOutput/inputOutput.ino
+++ b/arduino/SpacebrewYun/examples/inputOutput/inputOutput.ino
@@ -45,6 +45,9 @@ void setup() {
 	// start-up the bridge
 	Bridge.begin();
 
+  // strar-up the console
+  Console.begin();
+
 	// configure the spacebrew object to print status messages to serial
 	sb.verbose(true);
 

--- a/arduino/SpacebrewYun/examples/spacebrewBoolean/spacebrewBoolean.ino
+++ b/arduino/SpacebrewYun/examples/spacebrewBoolean/spacebrewBoolean.ino
@@ -45,6 +45,9 @@ void setup() {
 	// start-up the bridge
 	Bridge.begin();
 
+  // strar-up the console
+  Console.begin();
+
 	// configure the spacebrew object to print status messages to serial
 	sb.verbose(true);
 

--- a/arduino/SpacebrewYun/examples/spacebrewRange/spacebrewRange.ino
+++ b/arduino/SpacebrewYun/examples/spacebrewRange/spacebrewRange.ino
@@ -46,6 +46,9 @@ void setup() {
 	// start-up the bridge
 	Bridge.begin();
 
+  // strar-up the console
+  Console.begin();
+
 	// configure the spacebrew object to print status messages to serial
 	sb.verbose(true);
 

--- a/arduino/SpacebrewYun/examples/spacebrewString/spacebrewString.ino
+++ b/arduino/SpacebrewYun/examples/spacebrewString/spacebrewString.ino
@@ -43,6 +43,9 @@ void setup() {
 	// start-up the bridge
 	Bridge.begin();
 
+  // strar-up the console
+  Console.begin();
+  
 	// configure the spacebrew object to print status messages to serial
 	sb.verbose(true);
 


### PR DESCRIPTION
Tests done in Arduino IDE 1.6.7
I found that changes to library Yun, it is necessary to initialize Console.begin() on the strup() the example to work
Thank you for creating this library
